### PR TITLE
fix: prevent 404 on refresh by adding a vercel.json rewrite

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
The reason for the issue was that vercel being a server, would expect there to be a **profile.html** or **result.html** file on the /profile and /result routes respectively. However since that's not the case it would return a 404 on refresh.

### Solution: vercel.json
It's used to configure vercel to serve index.html for every route. After that react router can handle the routes on the client just like in a development environment.

Closes #35 